### PR TITLE
Fixed issue with CodeEditor loading/reloading

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -2,30 +2,30 @@ name: .NET Core
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.303
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
-    - name: Publish  
-      uses: brandedoutcast/publish-nuget@v2.5.2  
-      with:   
-       PROJECT_FILE_PATH: Tessin.Bladerunner/Tessin.Bladerunner.csproj
-       NUGET_KEY: ${{secrets.NUGET_API_KEY}} 
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.303
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+      - name: Publish
+        if: github.event_name != 'pull_request'
+        uses: brandedoutcast/publish-nuget@v2.5.2
+        with:
+          PROJECT_FILE_PATH: Tessin.Bladerunner/Tessin.Bladerunner.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/Tessin.Bladerunner/Cdnjs.cs
+++ b/Tessin.Bladerunner/Cdnjs.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tessin.Bladerunner
+{
+    /// <summary>
+    /// We use CDNJS from Cloudflare it is fast and reliable.
+    /// </summary>
+    class Cdnjs
+    {
+        public static string GetUrl(string packageName, string packageVersion, string path)
+        {
+            return "https://cdnjs.cloudflare.com/ajax/libs/" + packageName + "/" + packageVersion + "/" + path;
+        }
+
+        public static readonly string Require_js = "require.js";
+        public static readonly string Require_jsVersion = "2.3.6";
+        public static readonly string Require_jsUrl = GetUrl(Require_js, Require_jsVersion, "require.js");
+
+        public static readonly string Monaco = "monaco-editor";
+        public static readonly string MonacoVersion = "0.34.1";
+        public static readonly string MonacoRoot = GetUrl(Monaco, MonacoVersion, "min/"); // with trailing slash!
+        public static readonly string MonacoMainCssUrl = GetUrl(Monaco, MonacoVersion, "min/vs/editor/editor.main.min.css");
+    }
+}

--- a/Tessin.Bladerunner/Controls/CodeEditor.js
+++ b/Tessin.Bladerunner/Controls/CodeEditor.js
@@ -1,0 +1,156 @@
+﻿// https://github.com/microsoft/monaco-editor/blob/main/samples/browser-amd-editor/index.html
+const fs = require('node:fs')
+
+function bootstrap(__CDNJS__, __MSBUILD_CONFIG__) {
+    (async function (window) {
+        const env = __MSBUILD_CONFIG__;
+
+        console.log("Hello LINQPad!", { env });
+
+        if (!window["MonacoEnvironment"]) {
+            if (env === "Debug") {
+                // This code is necessary to preserve CSS loaded dynamically from JS (dev only)
+
+                let head = [];
+
+                const document_open = document.open;
+                document.open = function () {
+                    head = [];
+                    for (const el of document.head.childNodes) {
+                        head.push(el);
+                    }
+                    return document_open.call(document);
+                };
+
+                const document_close = document.close;
+                document.close = function () {
+                    const ret = document_close.call(document);
+                    let i = head.findIndex((el) => el.tagName === "SCRIPT");
+                    for (; i < head.length; i++) {
+                        const styleLink = head[i];
+                        if (styleLink.tagName === "STYLE" || styleLink.tagName === "LINK") {
+                            document.head.appendChild(styleLink);
+                        }
+                    }
+                    return ret;
+                };
+            }
+
+            /** @type {string} */
+            const cdnjs = __CDNJS__;
+
+            window.require.config({
+                paths: {
+                    vs: cdnjs + "/vs",
+                },
+            });
+
+            const workerSnippet = [
+                `self.MonacoEnvironment = { baseUrl: ${JSON.stringify(cdnjs)} }`,
+                `importScripts(${JSON.stringify(
+                    cdnjs + "/vs/base/worker/workerMain.min.js"
+                )})`,
+            ];
+
+            window["MonacoEnvironment"] = {
+                getWorkerUrl: () =>
+                    `data:text/javascript;charset=utf-8,${encodeURIComponent(
+                        workerSnippet.join(";")
+                    )}`,
+            };
+
+            const editors = new WeakMap();
+
+            function getMonacoEditor(/** @type {string} */ elementId) {
+                const el = document.getElementById(elementId);
+                if (el) {
+                    return editors.get(el);
+                }
+                return undefined;
+            }
+
+            function getTextModel(/** @type {string} */ elementId) {
+                const ed = getMonacoEditor(elementId);
+                if (ed) {
+                    return ed.getModel();
+                }
+                return undefined;
+            }
+
+            window["__monacoEditor_create"] = function (elementId, options) {
+                window.require(["vs/editor/editor.main"], (monaco) => {
+                    if (getMonacoEditor(elementId)) {
+                        // Note sure if this really is a problem but it can't work any other way
+                        console.warn("will not re-create monaco editor", { elementId });
+                        return;
+                    }
+                    const el = document.getElementById(elementId);
+                    const ed = monaco.editor.create(el, {
+                        lineNumbers: false,
+                        lineDecorationsWidth: 7,
+                        automaticLayout: false, // don't use automatic layout; it is expensive
+                        wordWrap: true,
+                        padding: {
+                            top: 30,
+                        },
+                        renderLineHighlight: false,
+                        folding: false,
+                        minimap: {
+                            enabled: false,
+                        },
+                        theme: "vs-dry",
+                        ...(JSON.parse(options) ?? {}),
+                    });
+
+                    let timeout
+                    const obs = new ResizeObserver((e) => {
+                        clearTimeout(timeout)
+                        timeout = setTimeout(() => {
+                            ed.layout({
+                                width: e[0].contentRect.width,
+                                height: e[0].contentRect.height,
+                            });
+                        },500)
+                    });
+
+                    obs.observe(el);
+
+                    editors.set(el, ed);
+                });
+            };
+
+            window["__monacoEditor_getText"] = function (elementId) {
+                const m = getTextModel(elementId);
+                if (m) {
+                    return m.getValue();
+                }
+                return "";
+            };
+
+            window["__monacoEditor_setText"] = function (elementId, newValue) {
+                const m = getTextModel(elementId);
+                if (m) {
+                    m.setValue(newValue);
+                }
+            };
+        }
+    })(window);
+}
+
+// build function with variable substitution
+
+const s = bootstrap.toString();
+const i = s.indexOf("{");
+const j = s.lastIndexOf("}");
+
+const { CDNJS_BASE, MSBUILD_CONFIG } = process.env
+
+console.debug("build code editor", { CDNJS_BASE, MSBUILD_CONFIG })
+
+fs.writeFileSync(process.argv.slice(2)[0],
+    bootstrap
+        .toString()
+        .slice(i + 1, j)
+        .replace("__CDNJS__", JSON.stringify(CDNJS_BASE))
+        .replace("__MSBUILD_CONFIG__", JSON.stringify(MSBUILD_CONFIG))
+)

--- a/Tessin.Bladerunner/Controls/CodeEditor.min.js
+++ b/Tessin.Bladerunner/Controls/CodeEditor.min.js
@@ -1,0 +1,134 @@
+
+    (async function (window) {
+        const env = "Release";
+
+        console.log("Hello LINQPad!", { env });
+
+        if (!window["MonacoEnvironment"]) {
+            if (env === "Debug") {
+                // This code is necessary to preserve CSS loaded dynamically from JS (dev only)
+
+                let head = [];
+
+                const document_open = document.open;
+                document.open = function () {
+                    head = [];
+                    for (const el of document.head.childNodes) {
+                        head.push(el);
+                    }
+                    return document_open.call(document);
+                };
+
+                const document_close = document.close;
+                document.close = function () {
+                    const ret = document_close.call(document);
+                    let i = head.findIndex((el) => el.tagName === "SCRIPT");
+                    for (; i < head.length; i++) {
+                        const styleLink = head[i];
+                        if (styleLink.tagName === "STYLE" || styleLink.tagName === "LINK") {
+                            document.head.appendChild(styleLink);
+                        }
+                    }
+                    return ret;
+                };
+            }
+
+            /** @type {string} */
+            const cdnjs = "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.34.1/min";
+
+            window.require.config({
+                paths: {
+                    vs: cdnjs + "/vs",
+                },
+            });
+
+            const workerSnippet = [
+                `self.MonacoEnvironment = { baseUrl: ${JSON.stringify(cdnjs)} }`,
+                `importScripts(${JSON.stringify(
+                    cdnjs + "/vs/base/worker/workerMain.min.js"
+                )})`,
+            ];
+
+            window["MonacoEnvironment"] = {
+                getWorkerUrl: () =>
+                    `data:text/javascript;charset=utf-8,${encodeURIComponent(
+                        workerSnippet.join(";")
+                    )}`,
+            };
+
+            const editors = new WeakMap();
+
+            function getMonacoEditor(/** @type {string} */ elementId) {
+                const el = document.getElementById(elementId);
+                if (el) {
+                    return editors.get(el);
+                }
+                return undefined;
+            }
+
+            function getTextModel(/** @type {string} */ elementId) {
+                const ed = getMonacoEditor(elementId);
+                if (ed) {
+                    return ed.getModel();
+                }
+                return undefined;
+            }
+
+            window["__monacoEditor_create"] = function (elementId, options) {
+                window.require(["vs/editor/editor.main"], (monaco) => {
+                    if (getMonacoEditor(elementId)) {
+                        // Note sure if this really is a problem but it can't work any other way
+                        console.warn("will not re-create monaco editor", { elementId });
+                        return;
+                    }
+                    const el = document.getElementById(elementId);
+                    const ed = monaco.editor.create(el, {
+                        lineNumbers: false,
+                        lineDecorationsWidth: 7,
+                        automaticLayout: false, // don't use automatic layout; it is expensive
+                        wordWrap: true,
+                        padding: {
+                            top: 30,
+                        },
+                        renderLineHighlight: false,
+                        folding: false,
+                        minimap: {
+                            enabled: false,
+                        },
+                        theme: "vs-dry",
+                        ...(JSON.parse(options) ?? {}),
+                    });
+
+                    let timeout
+                    const obs = new ResizeObserver((e) => {
+                        clearTimeout(timeout)
+                        timeout = setTimeout(() => {
+                            ed.layout({
+                                width: e[0].contentRect.width,
+                                height: e[0].contentRect.height,
+                            });
+                        },500)
+                    });
+
+                    obs.observe(el);
+
+                    editors.set(el, ed);
+                });
+            };
+
+            window["__monacoEditor_getText"] = function (elementId) {
+                const m = getTextModel(elementId);
+                if (m) {
+                    return m.getValue();
+                }
+                return "";
+            };
+
+            window["__monacoEditor_setText"] = function (elementId, newValue) {
+                const m = getTextModel(elementId);
+                if (m) {
+                    m.setValue(newValue);
+                }
+            };
+        }
+    })(window);

--- a/Tessin.Bladerunner/Editors/CodeEditor.cs
+++ b/Tessin.Bladerunner/Editors/CodeEditor.cs
@@ -25,7 +25,7 @@ namespace Tessin.Bladerunner.Editors
         {
             var value = Convert.ToString(editorFieldInfo.GetValue(obj));
 
-            _codeBox = new Controls.CodeEditor(value, _language);
+            _codeBox = new Controls.CodeEditor(new() { value = value, language = _language });
             _codeBox.TextInput += (sender, args) => updated();
 
             return _field = new Field(

--- a/Tessin.Bladerunner/Tessin.Bladerunner.csproj
+++ b/Tessin.Bladerunner/Tessin.Bladerunner.csproj
@@ -11,6 +11,7 @@
     <Compile Remove="Query\**" />
     <EmbeddedResource Remove="Query\**" />
     <None Remove="Query\**" />
+    <None Remove="Controls\CodeEditor.min.js" />
     <EmbeddedResource Update="Svg\SvgScripts.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>SvgScripts.Designer.cs</LastGenOutput>
@@ -65,5 +66,28 @@
   <ItemGroup>
     <Folder Include="linqpad-samples\" />
   </ItemGroup>
+
+  <!--
+  https://learn.microsoft.com/en-us/visualstudio/msbuild/tutorial-custom-task-code-generation?source=recommendations&view=vs-2022
+  -->
+
+  <PropertyGroup>
+    <CdnjsBase>https://cdnjs.cloudflare.com/ajax/libs</CdnjsBase>
+    <CdnjsMonacoEditorName>monaco-editor</CdnjsMonacoEditorName>
+    <CdnjsMonacoEditorVersion>0.34.1</CdnjsMonacoEditorVersion>
+    <CdnjsMonacoEditorBase>$(CdnjsBase)/$(CdnjsMonacoEditorName)/$(CdnjsMonacoEditorVersion)/min</CdnjsMonacoEditorBase>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Controls\CodeEditor.min.js" />
+  </ItemGroup>
+
+  <Target Name="GenerateCodeEditor" BeforeTargets="CoreCompile" Inputs="Controls\CodeEditor.js" Outputs="Controls\CodeEditor.min.js">
+    <Exec Command="node Controls\CodeEditor.js Controls\CodeEditor.min.js" EnvironmentVariables="CDNJS_BASE=$(CdnjsMonacoEditorBase);MSBUILD_CONFIG=$(Configuration)" />
+  </Target>
+
+  <Target Name="ForceGenerateCodeEditorOnRebuild" AfterTargets="CoreClean">
+    <Delete Files="Controls\CodeEditor.min.js" />
+  </Target>
 
 </Project>

--- a/Tessin.Bladerunner/Tessin.Bladerunner.csproj
+++ b/Tessin.Bladerunner/Tessin.Bladerunner.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>9</LangVersion>
     <!-- Use same major version as LINQPad.Runtime, when LINQPad 7 is released we can maintain backwards compatability -->
-    <Version>6.0.60</Version>
+    <Version>6.0.61</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tessin.Bladerunner/linqpad-samples/Controls/CodeEditor.linq
+++ b/Tessin.Bladerunner/linqpad-samples/Controls/CodeEditor.linq
@@ -1,5 +1,5 @@
 <Query Kind="Program">
-  <Reference>C:\Repos\tessin-bladerunner\Tessin.Bladerunner\bin\Debug\netcoreapp3.1\Tessin.Bladerunner.dll</Reference>
+  <Reference Relative="..\..\bin\Debug\netcoreapp3.1\Tessin.Bladerunner.dll">C:\Users\JohnLeidegren\code\tessin-bladerunner\Tessin.Bladerunner\bin\Debug\netcoreapp3.1\Tessin.Bladerunner.dll</Reference>
   <Namespace>System.Drawing</Namespace>
   <Namespace>System.Threading.Tasks</Namespace>
   <Namespace>Tessin.Bladerunner</Namespace>


### PR DESCRIPTION
These changes fixes issues with race conditions, Monaco<->HtmlElement bindings and code loading. Switch to CDNJS for stability and locked all versions.